### PR TITLE
Disable and mask update-engine

### DIFF
--- a/disable-update-engine
+++ b/disable-update-engine
@@ -1,0 +1,17 @@
+for id in `fleetctl list-machines | grep -v "MACHINE" | awk '{print $1}' | tail -5 | tr -d "." | xargs`; do fleetctl ssh $id sudo systemctl stop update-engine; done
+for id in `fleetctl list-machines | grep -v "MACHINE" | awk '{print $1}' | tail -5 | tr -d "." | xargs`; do fleetctl ssh $id sudo systemctl mask update-engine; done
+for id in `fleetctl list-machines | grep -v "MACHINE" | awk '{print $1}' | tail -5 | tr -d "." | xargs`; do fleetctl ssh $id sudo systemctl -n0 status update-engine; done
+
+Output for the last command should be something like:
+● update-engine.service
+   Loaded: masked (/dev/null; bad)
+   Active: failed (Result: exit-code) since Mon 2016-10-10 05:22:06 UTC; 1h 47min ago
+ Main PID: 742 (code=exited, status=1/FAILURE)
+● update-engine.service
+   Loaded: masked (/dev/null; bad)
+   Active: failed (Result: exit-code) since Mon 2016-10-10 05:22:05 UTC; 1h 47min ago
+ Main PID: 910 (code=exited, status=1/FAILURE)
+● update-engine.service
+   Loaded: masked (/dev/null; bad)
+   Active: failed (Result: exit-code) since Mon 2016-10-10 05:22:06 UTC; 1h 47min ago
+ Main PID: 923 (code=exited, status=1/FAILURE)


### PR DESCRIPTION
- to avoid and surprise upgrades, we have to stop and [mask ](https://fedoramagazine.org/systemd-masking-units/)the update-engine 
- tried in xp and pub-xp, works
- this will be built into the provisioners if possible, but must be manually applied too
- this PR is for applying this to pre-prods and the prods, both delivery and publishing
